### PR TITLE
Add parameter types to OptimalControlProgram

### DIFF
--- a/bioptim/optimization/optimal_control_program.py
+++ b/bioptim/optimization/optimal_control_program.py
@@ -62,6 +62,21 @@ from ..optimization.parameters import ParameterList, Parameter, ParameterContain
 from ..optimization.solution.solution import Solution
 from ..optimization.solution.solution_data import SolutionMerge
 from ..optimization.variable_scaling import VariableScalingList, VariableScaling
+from ..misc.parameters_types import (
+    Int,
+    Float,
+    Bool,
+    Str,
+    AnyIterable,
+    AnyTuple,
+    AnyList,
+    AnyListOptional,
+    IntOptional,
+    AnyDict,
+    DoubleNpArrayTuple,
+    NpArray,
+    CX,
+)
 
 
 class OptimalControlProgram:
@@ -408,25 +423,25 @@ class OptimalControlProgram:
 
     def _check_arguments_and_build_nlp(
         self,
-        dynamics,
+        dynamics: Dynamics | DynamicsList,
         objective_functions,
         constraints,
         parameters,
-        phase_transitions,
-        multinode_constraints,
-        multinode_objectives,
-        parameter_bounds,
-        parameter_init,
-        parameter_constraints,
-        parameter_objectives,
-        use_sx,
-        bio_model,
-        plot_mappings,
-        time_phase_mapping,
-        control_type,
-        variable_mappings,
-        integrated_value_functions,
-    ):
+        phase_transitions: PhaseTransitionList,
+        multinode_constraints: MultinodeConstraintList,
+        multinode_objectives: MultinodeObjectiveList,
+        parameter_bounds: BoundsList,
+        parameter_init: InitialGuessList,
+        parameter_constraints: ParameterConstraintList,
+        parameter_objectives: ParameterObjectiveList,
+        use_sx: Bool,
+        bio_model: list | tuple | BioModel,
+        plot_mappings: Mapping | None,
+        time_phase_mapping: BiMapping,
+        control_type: ControlType | AnyList,
+        variable_mappings: BiMappingList,
+        integrated_value_functions: dict[str, Callable] | None,
+    ) -> AnyTuple:
         if objective_functions is None:
             objective_functions = ObjectiveList()
         elif isinstance(objective_functions, Objective):
@@ -604,8 +619,16 @@ class OptimalControlProgram:
                 )
 
     def _prepare_bounds_and_init(
-        self, x_bounds, u_bounds, parameter_bounds, a_bounds, x_init, u_init, parameter_init, a_init
-    ):
+        self,
+        x_bounds: BoundsList,
+        u_bounds: BoundsList,
+        parameter_bounds: BoundsList,
+        a_bounds: BoundsList,
+        x_init: InitialGuessList,
+        u_init: InitialGuessList,
+        parameter_init: InitialGuessList,
+        a_init: InitialGuessList,
+    ) -> None:
         self.parameter_bounds = BoundsList()
         self.parameter_init = InitialGuessList()
 
@@ -620,7 +643,7 @@ class OptimalControlProgram:
         multinode_objectives: ObjectiveList,
         constraints: ConstraintList,
         phase_transition: PhaseTransitionList,
-    ):
+    ) -> None:
         """
         This function declares the multi node penalties (constraints and objectives) to the penalty pool.
 
@@ -633,12 +656,12 @@ class OptimalControlProgram:
 
     def _finalize_penalties(
         self,
-        constraints,
-        parameter_constraints,
-        objective_functions,
-        parameter_objectives,
-        phase_transitions,
-    ):
+        constraints: ConstraintList,
+        parameter_constraints: ParameterConstraintList,
+        objective_functions: ObjectiveList,
+        parameter_objectives: ParameterObjectiveList,
+        phase_transitions: PhaseTransitionList,
+    ) -> None:
         # Define continuity constraints
         # Prepare phase transitions (Reminder, it is important that parameters are declared before,
         # otherwise they will erase the phase_transitions)
@@ -657,7 +680,7 @@ class OptimalControlProgram:
         self.update_parameter_objectives(parameter_objectives)
         return
 
-    def finalize_plot_phase_mappings(self):
+    def finalize_plot_phase_mappings(self) -> None:
         """
         Finalize the plot phase mappings (if not already done)
 
@@ -725,19 +748,19 @@ class OptimalControlProgram:
                     nlp.plot[key].phase_mappings = BiMapping(to_first=range(size), to_second=range(size))
 
     @property
-    def variables_vector(self):
+    def variables_vector(self) -> CX:
         return OptimizationVectorHelper.vector(self)
 
     @property
-    def bounds_vectors(self):
+    def bounds_vectors(self) -> DoubleNpArrayTuple:
         return OptimizationVectorHelper.bounds_vectors(self)
 
     @property
-    def init_vector(self):
+    def init_vector(self) -> NpArray:
         return OptimizationVectorHelper.init_vector(self)
 
     @classmethod
-    def from_loaded_data(cls, data):
+    def from_loaded_data(cls, data: AnyDict) -> "OptimalControlProgram":
         """
         Loads an OCP from a dictionary ("ocp_initializer")
 
@@ -757,7 +780,7 @@ class OptimalControlProgram:
 
         return cls(**data)
 
-    def _set_kinematic_phase_mapping(self):
+    def _set_kinematic_phase_mapping(self) -> AnyTuple:
         """
         To add phase_mapping for different kinematic number of states in the ocp. It maps the degrees of freedom
         across phases, so they appear on the same graph.
@@ -803,7 +826,7 @@ class OptimalControlProgram:
 
         return biomodels
 
-    def _prepare_option_dict_for_phase(self, name: str, option_dict: OptionDict, option_dict_type: type) -> Any:
+    def _prepare_option_dict_for_phase(self, name: Str, option_dict: OptionDict, option_dict_type: type) -> OptionDict:
         if option_dict is None:
             option_dict = option_dict_type()
 
@@ -864,7 +887,7 @@ class OptimalControlProgram:
             )
             penalty.add_or_replace_to_penalty_pool(self, nlp)
 
-    def _declare_phase_transition_continuity(self, pt):
+    def _declare_phase_transition_continuity(self, pt: PhaseTransition) -> None:
         """Declare the continuity function for the variables between phases, mainly for the state variables"""
         # Phase transition as constraints
         if pt.type == PhaseTransitionFcn.DISCONTINUOUS:
@@ -916,7 +939,9 @@ class OptimalControlProgram:
         else:
             raise RuntimeError("new_objective_function must be a ParameterObjective or an ParameterObjectiveList")
 
-    def update_objectives_target(self, target, phase=None, list_index=None):
+    def update_objectives_target(
+        self, target: NpArray, phase: IntOptional = None, list_index: IntOptional = None
+    ) -> None:
         """
         Fast accessor to update the target of a specific objective function. To update target of global objective
         (usually defined by parameters), one can pass 'phase=-1'
@@ -940,7 +965,7 @@ class OptimalControlProgram:
 
         ObjectiveFunction.update_target(self.nlp[phase] if phase >= 0 else self, list_index, target)
 
-    def update_constraints(self, new_constraints: Constraint | ConstraintList):
+    def update_constraints(self, new_constraints: Constraint | ConstraintList) -> None:
         """
         The main user interface to add or modify constraint in the ocp
 
@@ -960,7 +985,7 @@ class OptimalControlProgram:
         else:
             raise RuntimeError("new_constraint must be a Constraint or a ConstraintList")
 
-    def update_parameter_constraints(self, new_constraint: ParameterConstraint | ParameterConstraintList):
+    def update_parameter_constraints(self, new_constraint: ParameterConstraint | ParameterConstraintList) -> None:
         """
         The main user interface to add or modify a parameter constraint in the ocp
 
@@ -980,7 +1005,7 @@ class OptimalControlProgram:
         else:
             raise RuntimeError("new_constraint must be a ParameterConstraint or a ParameterConstraintList")
 
-    def _declare_parameters(self, parameters: ParameterList):
+    def _declare_parameters(self, parameters: ParameterList) -> None:
         """
         The main user interface to add or modify parameters in the ocp
 
@@ -1002,7 +1027,7 @@ class OptimalControlProgram:
         u_bounds: BoundsList = None,
         parameter_bounds: BoundsList = None,
         a_bounds: BoundsList = None,
-    ):
+    ) -> None:
         """
         The main user interface to add bounds in the ocp to nlps.
 
@@ -1065,7 +1090,7 @@ class OptimalControlProgram:
         u_init: InitialGuessList = None,
         parameter_init: InitialGuessList = None,
         a_init: InitialGuessList = None,
-    ):
+    ) -> None:
         """
         The main user interface to add initial guesses in the ocp
 
@@ -1119,7 +1144,7 @@ class OptimalControlProgram:
             for key in parameter_init.keys():
                 self.parameter_init.add(key, parameter_init[key], phase=0)
 
-    def add_plot(self, fig_name: str, update_function: Callable, phase: int = -1, **parameters: Any):
+    def add_plot(self, fig_name: Str, update_function: Callable, phase: Int = -1, **parameters: Any) -> None:
         """
         The main user interface to add a new plot to the ocp
 
@@ -1166,7 +1191,7 @@ class OptimalControlProgram:
 
         nlp.plot[plot_name] = custom_plot
 
-    def add_plot_penalty(self, cost_type: CostType = None):
+    def add_plot_penalty(self, cost_type: CostType = None) -> None:
         """
         To add penlaty (objectivs and constraints) plots
 
@@ -1291,19 +1316,19 @@ class OptimalControlProgram:
             add_penalty(penalties_implicit)
         return
 
-    def add_plot_ipopt_outputs(self):
+    def add_plot_ipopt_outputs(self) -> None:
         self.plot_ipopt_outputs = True
 
-    def add_plot_check_conditioning(self):
+    def add_plot_check_conditioning(self) -> None:
         self.plot_check_conditioning = True
 
-    def save_intermediary_ipopt_iterations(self, path_to_results, result_file_name, nb_iter_save):
+    def save_intermediary_ipopt_iterations(self, path_to_results: Str, result_file_name: Str, nb_iter_save: Int) -> None:
         self.save_ipopt_iterations_info = SaveIterationsInfo(path_to_results, result_file_name, nb_iter_save)
 
     def prepare_plots(
         self,
-        automatically_organize: bool = True,
-        show_bounds: bool = False,
+        automatically_organize: Bool = True,
+        show_bounds: Bool = False,
         shooting_type: Shooting = Shooting.MULTIPLE,
         integrator: SolutionIntegrator = SolutionIntegrator.OCP,
     ) -> PlotOcp:
@@ -1335,14 +1360,14 @@ class OptimalControlProgram:
             dummy_phase_times=OptimizationVectorHelper.extract_step_times(self, casadi.DM(np.ones(self.n_phases))),
         )
 
-    def check_conditioning(self):
+    def check_conditioning(self) -> None:
         """
         Visualisation of jacobian and hessian contraints and hessian objective for each phase at initial time
         """
         check_conditioning(self)
 
     def solve(
-        self, solver: GenericSolver = None, warm_start: Solution = None, expand_during_shake_tree=False
+        self, solver: GenericSolver = None, warm_start: Solution | None = None, expand_during_shake_tree: Bool = False
     ) -> Solution:
         """
         Call the solver to actually solve the ocp
@@ -1397,7 +1422,7 @@ class OptimalControlProgram:
 
         return Solution.from_dict(self, self.ocp_solver.get_optimized_value())
 
-    def set_warm_start(self, sol: Solution):
+    def set_warm_start(self, sol: Solution) -> None:
         """
         Modify x and u initial guess based on a solution.
 
@@ -1445,9 +1470,9 @@ class OptimalControlProgram:
 
     def print(
         self,
-        to_console: bool = True,
-        to_graph: bool = True,
-    ):
+        to_console: Bool = True,
+        to_graph: Bool = True,
+    ) -> None:
         if to_console:
             display_console = OcpToConsole(self)
             display_console.print()
@@ -1457,8 +1482,8 @@ class OptimalControlProgram:
             display_graph.print()
 
     def _define_time(
-        self, phase_time: int | float | list | tuple, objective_functions: ObjectiveList, constraints: ConstraintList
-    ):
+        self, phase_time: Int | Float | AnyIterable, objective_functions: ObjectiveList, constraints: ConstraintList
+    ) -> None:
         """
         Declare the phase_time vector in v. If objective_functions or constraints defined a time optimization,
         a sanity check is perform and the values of initial guess and bounds for these particular phases
@@ -1476,8 +1501,8 @@ class OptimalControlProgram:
         def define_parameters_phase_time(
             ocp: OptimalControlProgram,
             penalty_functions: ObjectiveList | ConstraintList,
-            _has_penalty: list = None,
-        ) -> list:
+            _has_penalty: AnyListOptional = None,
+        ) -> AnyList:
             """
             Sanity check to ensure that only one time optimization is defined per phase. It also creates the time vector
             for initial guesses and bounds
@@ -1576,7 +1601,7 @@ class OptimalControlProgram:
             "dt_initial_guess", initial_guess=[v for v in dt_initial_guess.values()]
         )
 
-    def _define_numerical_timeseries(self, dynamics):
+    def _define_numerical_timeseries(self, dynamics: DynamicsList) -> None:
         """
         Declare the numerical_timeseries symbolic variables.
 
@@ -1609,7 +1634,7 @@ class OptimalControlProgram:
         # Add to the nlp
         NLP.add(self, "numerical_timeseries", numerical_timeseries, True)
 
-    def _modify_penalty(self, new_penalty: PenaltyOption | Parameter):
+    def _modify_penalty(self, new_penalty: PenaltyOption | Parameter) -> None:
         """
         The internal function to modify a penalty.
 
@@ -1626,7 +1651,7 @@ class OptimalControlProgram:
 
         self.program_changed = True
 
-    def _modify_parameter_penalty(self, new_penalty: PenaltyOption | Parameter):
+    def _modify_parameter_penalty(self, new_penalty: PenaltyOption | Parameter) -> None:
         """
         The internal function to modify a parameter penalty.
 
@@ -1642,7 +1667,7 @@ class OptimalControlProgram:
         new_penalty.add_or_replace_to_penalty_pool(self, self.nlp[new_penalty.phase])
         self.program_changed = True
 
-    def node_time(self, phase_idx: int, node_idx: int):
+    def node_time(self, phase_idx: Int, node_idx: Int) -> Float:
         """
         Gives the time of the node node_idx of from the phase phase_idx
 
@@ -1665,7 +1690,7 @@ class OptimalControlProgram:
 
         return previous_phase_time + self.nlp[phase_idx].dt * node_idx
 
-    def _set_nlp_is_stochastic(self):
+    def _set_nlp_is_stochastic(self) -> None:
         """
         Set the is_stochastic variable to False
         because it's not relevant for traditional OCP,_


### PR DESCRIPTION
## Summary
- use parameter_types aliases in OptimalControlProgram
- annotate return types and parameters

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*