### PR TITLE
Add parameter type hints

### DIFF
--- a/bioptim/optimization/parameters.py
+++ b/bioptim/optimization/parameters.py
@@ -1,7 +1,18 @@
 from typing import Callable, Any
 
+from ..misc.parameters_types import (
+    Bool,
+    Int,
+    IntOptional,
+    Str,
+    AnyListOptional,
+    Range,
+    CX,
+)
+
 from casadi import MX, SX, vertcat
 import numpy as np
+from ..models.protocols.biomodel import BioModel
 
 from ..misc.mapping import BiMapping
 from ..optimization.variable_scaling import VariableScaling, VariableScalingList
@@ -20,18 +31,18 @@ class Parameter(OptimizationVariable):
 
     def __init__(
         self,
-        name: str,
+        name: Str,
         mx: MX,
-        cx_start: list | None,
-        index: range | list,
-        mapping: BiMapping = None,
-        parent_list=None,
-        function: Callable = None,
-        size: int = None,
-        cx_type: Callable | MX | SX = None,
-        scaling: VariableScaling = None,
+        cx_start: AnyListOptional,
+        index: Range | AnyList,
+        mapping: BiMapping | None = None,
+        parent_list: "ParameterList" | None = None,
+        function: Callable | None = None,
+        size: IntOptional = None,
+        cx_type: Callable | CX | None = None,
+        scaling: VariableScaling | None = None,
         **kwargs: Any,
-    ):
+    ) -> None:
         """
         Parameters
         ----------
@@ -65,19 +76,19 @@ class Parameter(OptimizationVariable):
         self._mx = mx
 
     @property
-    def mx(self):
+    def mx(self) -> CX:
         # TODO: this should removed and placed in the BiorbdModel
         return self._mx
 
     @property
-    def cx(self):
+    def cx(self) -> CX:
         if self.parent_list is not None:
             return self.cx_start
         else:
             return self.cx_start()
 
     @property
-    def cx_start(self):
+    def cx_start(self) -> CX:
         """
         The CX of the variable
         """
@@ -88,16 +99,16 @@ class Parameter(OptimizationVariable):
             )
         return self.parent_list.cx_start[self.index]
 
-    def cx_mid(self):
+    def cx_mid(self) -> None:
         raise RuntimeError("cx_mid is not available for parameters, only cx_start is accepted.")
 
-    def cx_end(self):
+    def cx_end(self) -> None:
         raise RuntimeError("cx_end is not available for parameters, only cx_start is accepted.")
 
-    def cx_intermediates_list(self):
+    def cx_intermediates_list(self) -> None:
         raise RuntimeError("cx_intermediates_list is not available for parameters, only cx_start is accepted.")
 
-    def apply_parameter(self, model):
+    def apply_parameter(self, model: "BioModel") -> None:
         """
         Apply the parameter variables to the model. This should be called during the creation of the biomodel
         """
@@ -112,7 +123,7 @@ class ParameterList(OptimizationVariableList):
     A list of Parameters.
     """
 
-    def __init__(self, use_sx: bool):
+    def __init__(self, use_sx: Bool) -> None:
         cx_constructor = SX if use_sx else MX
         super(ParameterList, self).__init__(cx_constructor, phase_dynamics=PhaseDynamics.SHARED_DURING_THE_PHASE)
         self.cx_type = cx_constructor
@@ -123,25 +134,25 @@ class ParameterList(OptimizationVariableList):
         self.scaling = VariableScalingList()
 
     @property
-    def current_cx_to_get(self):
+    def current_cx_to_get(self) -> Int:
         return self._current_cx_to_get
 
     @current_cx_to_get.setter
-    def current_cx_to_get(self, index: int):
+    def current_cx_to_get(self, index: Int):
         raise RuntimeError(
             "current_cx_to_get is not changable for parameters, only cx_start is accepted (current_cx_to_get is always 0)."
         )
 
     def add(
         self,
-        name: str,
-        function: callable,
-        size: int,
+        name: Str,
+        function: Callable,
+        size: Int,
         scaling: VariableScaling,
-        mapping: BiMapping = None,
-        allow_reserved_name: bool = False,
+        mapping: BiMapping | None = None,
+        allow_reserved_name: Bool = False,
         **kwargs: Any,
-    ):
+    ) -> None:
         """
         Add a new Parameter to the list
         This function should be called by the user. It will create the parameter and add it to the list
@@ -202,7 +213,7 @@ class ParameterList(OptimizationVariableList):
             )
         )
 
-    def copy(self):
+    def copy(self) -> "ParameterList":
         """
         Copy a parameters list to new one
         """
@@ -228,20 +239,20 @@ class ParameterList(OptimizationVariableList):
 
         return parameters_copy
 
-    def cx_mid(self):
+    def cx_mid(self) -> None:
         raise RuntimeError("cx_mid is not available for parameters, only cx_start is accepted.")
 
-    def cx_end(self):
+    def cx_end(self) -> None:
         raise RuntimeError("cx_end is not available for parameters, only cx_start is accepted.")
 
-    def cx_intermediates_list(self):
+    def cx_intermediates_list(self) -> None:
         raise RuntimeError("cx_intermediates_list is not available for parameters, only cx_start is accepted.")
 
-    def add_a_copied_element(self, element_to_copy_index):
+    def add_a_copied_element(self, element_to_copy_index: Int) -> None:
         self.elements.append(self.elements[element_to_copy_index])
 
     @property
-    def mx(self):
+    def mx(self) -> MX:
         """
         Returns
         -------
@@ -261,19 +272,19 @@ class ParameterContainer(OptimizationVariableContainer):
     A parameter container (i.e., the list of scaled parameters and a list of unscaled parameters).
     """
 
-    def __init__(self, use_sx: bool):
+    def __init__(self, use_sx: Bool) -> None:
         super(ParameterContainer, self).__init__(phase_dynamics=PhaseDynamics.SHARED_DURING_THE_PHASE)
         self._parameters: ParameterList = ParameterList(use_sx=use_sx)
 
     @property
-    def node_index(self):
+    def node_index(self) -> Int:
         return self._node_index
 
     @node_index.setter
-    def node_index(self, value):
+    def node_index(self, value: Int):
         raise RuntimeError("node_index is not changable for parameters since it is the same for every node.")
 
-    def initialize(self, parameters: ParameterList):
+    def initialize(self, parameters: ParameterList) -> None:
         """
         Initialize the Container so the dimensions are correct.
 
@@ -288,18 +299,18 @@ class ParameterContainer(OptimizationVariableContainer):
         self._parameters = parameters.copy()
         return
 
-    def initialize_from_shooting(self, n_shooting: int, cx: Callable):
+    def initialize_from_shooting(self, n_shooting: Int, cx: Callable) -> None:
         raise RuntimeError("initialize_from_shooting is not available for parameters, only initialize is accepted.")
 
     @property
-    def parameters(self):
+    def parameters(self) -> ParameterList:
         """
         This method allows to intercept the scaled item and return the current node_index
         """
         return self._parameters
 
     @property
-    def unscaled(self):
+    def unscaled(self) -> ParameterList:
         """
         This method allows to intercept the scaled item and return the current node_index
 
@@ -313,34 +324,34 @@ class ParameterContainer(OptimizationVariableContainer):
         return self._parameters
 
     @property
-    def scaled(self):
+    def scaled(self) -> ParameterList:
         """
         This method allows to intercept the scaled item and return the current node_index
         """
         return self._parameters
 
-    def keys(self):
+    def keys(self) -> StrList:
         return self._parameters.keys()
 
-    def key_index(self, key):
+    def key_index(self, key: Str) -> Range | AnyList:
         return self._parameters[key].index
 
     @property
-    def shape(self):
+    def shape(self) -> Int:
         return self._parameters.shape
 
     @property
-    def cx_intermediates_list(self):
+    def cx_intermediates_list(self) -> AnyList:
         raise RuntimeError("cx_intermediates_list is not available for parameters, only cx_start is accepted.")
 
     @property
-    def cx_mid(self):
+    def cx_mid(self) -> CX:
         raise RuntimeError("cx_mid is not available for parameters, only cx_start is accepted.")
 
     @property
-    def cx_end(self):
+    def cx_end(self) -> CX:
         raise RuntimeError("cx_end is not available for parameters, only cx_start is accepted.")
 
     @property
-    def mx(self):
+    def mx(self) -> MX:
         return self.parameters.mx


### PR DESCRIPTION
## Summary
- annotate parameters module with parameter type aliases

## Testing
- `python -m py_compile bioptim/optimization/parameters.py`
- `cd voice_server/voice` *(fails: No such file or directory)*
- `poetry run pytest server/tests` *(fails: Poetry could not find a pyproject.toml file)*

------
https://chatgpt.com/codex/tasks/task_b_68465b0777088330b979c99855c27317