### PR TITLE
Fix type hints for optimization variables

### DIFF
--- a/bioptim/optimization/optimization_variable.py
+++ b/bioptim/optimization/optimization_variable.py
@@ -1,7 +1,18 @@
 from typing import Callable
 
+from ..misc.parameters_types import (
+    Int,
+    Range,
+    Str,
+    Bool,
+    AnyList,
+    StrList,
+    NpArray,
+    CX,
+)
+
 import numpy as np
-from casadi import MX, SX, vertcat
+from casadi import vertcat
 
 from ..misc.enums import PhaseDynamics
 from ..misc.mapping import BiMapping
@@ -36,11 +47,11 @@ class OptimizationVariable:
 
     def __init__(
         self,
-        name: str,
-        cx_start: list | None,
-        index: range | list,
+        name: Str,
+        cx_start: AnyList | CX | None,
+        index: Range | AnyList,
         mapping: BiMapping = None,
-        parent_list=None,
+        parent_list: "OptimizationVariableList" | None = None,
     ):
         """
         Parameters
@@ -54,13 +65,13 @@ class OptimizationVariable:
         parent_list: OptimizationVariableList
             The list the OptimizationVariable is in
         """
-        self.name: str = name
-        self.original_cx: list = cx_start
-        self.index: range | list = index
+        self.name: Str = name
+        self.original_cx: AnyList | CX | None = cx_start
+        self.index: Range | AnyList = index
         self.mapping: BiMapping = mapping
-        self.parent_list: OptimizationVariableList = parent_list
+        self.parent_list: "OptimizationVariableList" | None = parent_list
 
-    def __len__(self):
+    def __len__(self) -> Int:
         """
         The len of the MX reduced
 
@@ -71,7 +82,7 @@ class OptimizationVariable:
         return len(self.index)
 
     @property
-    def shape(self):
+    def shape(self) -> Int:
         """
         The len of the MX reduced
 
@@ -82,7 +93,7 @@ class OptimizationVariable:
         return len(self)
 
     @property
-    def cx(self) -> MX | SX:
+    def cx(self) -> CX:
         if self.parent_list is not None:
             if self.parent_list.current_cx_to_get == 0:
                 return self.cx_start
@@ -96,7 +107,7 @@ class OptimizationVariable:
             return self.cx_start
 
     @property
-    def cx_start(self) -> MX | SX:
+    def cx_start(self) -> CX:
         """
         The CX of the variable
         """
@@ -109,7 +120,7 @@ class OptimizationVariable:
         return self.parent_list.cx_start[self.index, :]
 
     @property
-    def cx_mid(self) -> MX | SX:
+    def cx_mid(self) -> CX:
         """
         The CX of the variable
         """
@@ -122,7 +133,7 @@ class OptimizationVariable:
         return self.parent_list.cx_mid[self.index, :]
 
     @property
-    def cx_end(self) -> MX | SX:
+    def cx_end(self) -> CX:
         """
         The CX of the variable
         """
@@ -135,7 +146,7 @@ class OptimizationVariable:
         return self.parent_list.cx_end[self.index, :]
 
     @property
-    def cx_intermediates_list(self) -> list:
+    def cx_intermediates_list(self) -> AnyList:
         """
         The cx of all elements together (starting point)
         """
@@ -176,18 +187,18 @@ class OptimizationVariableList:
         The number of variables in the list
     """
 
-    def __init__(self, cx_constructor, phase_dynamics):
-        self.elements: list = []
-        self.fake_elements: list = []
-        self._cx_start: MX | SX | np.ndarray = np.array([])
-        self._cx_mid: MX | SX | np.ndarray = np.array([])
-        self._cx_end: MX | SX | np.ndarray = np.array([])
-        self._cx_intermediates: list = [cx_constructor([])]
+    def __init__(self, cx_constructor: Callable, phase_dynamics: PhaseDynamics):
+        self.elements: AnyList = []
+        self.fake_elements: AnyList = []
+        self._cx_start: CX | NpArray = np.array([])
+        self._cx_mid: CX | NpArray = np.array([])
+        self._cx_end: CX | NpArray = np.array([])
+        self._cx_intermediates: AnyList = [cx_constructor([])]
         self.cx_constructor = cx_constructor
         self._current_cx_to_get = 0
         self.phase_dynamics = phase_dynamics
 
-    def __getitem__(self, item: int | str | list | range):
+    def __getitem__(self, item: Int | Str | AnyIterable | Range) -> "OptimizationVariable":
         """
         Get a specific variable in the list, whether by name or by index
 
@@ -226,15 +237,15 @@ class OptimizationVariableList:
         else:
             raise ValueError("OptimizationVariableList can be sliced with int, list, range or str only")
 
-    def __setitem__(self, key, value: OptimizationVariable):
+    def __setitem__(self, key: Int, value: OptimizationVariable) -> None:
         self.elements.append(value)
 
     @property
-    def current_cx_to_get(self):
+    def current_cx_to_get(self) -> Int:
         return self._current_cx_to_get
 
     @current_cx_to_get.setter
-    def current_cx_to_get(self, index: int):
+    def current_cx_to_get(self, index: Int) -> None:
         """
         Set the value of current_cx_to_get to corresponding index (cx_start for 0, cx_mid for 1, cx_end for 2) if
         phase_dynamics == PhaseDynamics.SHARED_DURING_PHASE. Otherwise, it is always cx_start
@@ -255,7 +266,7 @@ class OptimizationVariableList:
         else:
             self._current_cx_to_get = index if index != -1 else 2
 
-    def append_fake(self, name: str, index: MX | SX | list, bimapping: BiMapping):
+    def append_fake(self, name: Str, index: CX | AnyList, bimapping: BiMapping) -> None:
         """
         Add a new variable to the fake list which add something without changing the size of the normal elements
 
@@ -271,7 +282,7 @@ class OptimizationVariableList:
 
         self.fake_elements.append(OptimizationVariable(name, None, index, bimapping, self))
 
-    def append(self, name: str, cx: list, bimapping: BiMapping):
+    def append(self, name: Str, cx: AnyList, bimapping: BiMapping) -> None:
         """
         Add a new variable to the list
 
@@ -299,10 +310,10 @@ class OptimizationVariableList:
 
     def append_from_scaled(
         self,
-        name: str,
-        cx: list,
+        name: Str,
+        cx: AnyList,
         scaled_optimization_variable: "OptimizationVariableList",
-    ):
+    ) -> None:
         """
         Add a new variable to the list
 
@@ -392,7 +403,7 @@ class OptimizationVariableList:
 
         return self._cx_intermediates
 
-    def __contains__(self, item: str):
+    def __contains__(self, item: Str) -> Bool:
         """
         If the item of name item is in the list
         """
@@ -406,7 +417,7 @@ class OptimizationVariableList:
         else:
             return False
 
-    def keys(self):
+    def keys(self) -> StrList:
         """
         All the names of the elements in the list
         """
@@ -414,21 +425,21 @@ class OptimizationVariableList:
         return [elt for elt in self]
 
     @property
-    def shape(self):
+    def shape(self) -> Int:
         """
         The size of the CX
         """
 
         return self._cx_start.shape[0]
 
-    def __len__(self):
+    def __len__(self) -> Int:
         """
         The number of variables in the list
         """
 
         return len(self.elements)
 
-    def __iter__(self):
+    def __iter__(self) -> "OptimizationVariableList":
         """
         Allow for the list to be used in a for loop
 
@@ -440,7 +451,7 @@ class OptimizationVariableList:
         self._iter_idx = 0
         return self
 
-    def __next__(self):
+    def __next__(self) -> Str:
         """
         Get the next phase of the option list
 
@@ -466,22 +477,22 @@ class OptimizationVariableContainer:
             If the dynamics is the same for all the phase (effectively always setting _node_index to 0 even though the
             user sets it to something else)
         """
-        self.cx_constructor = None
-        self._unscaled: list[OptimizationVariableList] = []
-        self._scaled: list[OptimizationVariableList] = []
-        self._node_index = 0  # TODO: [0] to [node_index]
+        self.cx_constructor: Callable | None = None
+        self._unscaled: AnyList = []
+        self._scaled: AnyList = []
+        self._node_index: Int = 0  # TODO: [0] to [node_index]
         self.phase_dynamics = phase_dynamics
 
     @property
-    def node_index(self):
+    def node_index(self) -> Int:
         return self._node_index
 
     @node_index.setter
-    def node_index(self, value):
+    def node_index(self, value: Int) -> None:
         if self.phase_dynamics == PhaseDynamics.ONE_PER_NODE:
             self._node_index = value
 
-    def initialize_from_shooting(self, n_shooting: int, cx: Callable):
+    def initialize_from_shooting(self, n_shooting: Int, cx: Callable) -> None:
         """
         Initialize the Container so the dimensions are up to number of shooting points of the program
 
@@ -501,7 +512,7 @@ class OptimizationVariableContainer:
             self._scaled.append(OptimizationVariableList(cx, self.phase_dynamics))
             self._unscaled.append(OptimizationVariableList(cx, self.phase_dynamics))
 
-    def initialize_intermediate_cx(self, n_shooting: int, n_cx: int):
+    def initialize_intermediate_cx(self, n_shooting: Int, n_cx: Int) -> None:
         """
         Initialize the containers so the dimensions are up to the required intermediate points,
         especially important in collocations
@@ -518,7 +529,7 @@ class OptimizationVariableContainer:
             self._scaled[node_index]._cx_intermediates = [self.cx_constructor([]) for _ in range(n_cx)]
             self._unscaled[node_index]._cx_intermediates = [self.cx_constructor([]) for _ in range(n_cx)]
 
-    def __getitem__(self, item: int | str):
+    def __getitem__(self, item: Int | Str) -> OptimizationVariable:
         if isinstance(item, int):
             raise ValueError("To get a specific node, please set the node_index property then call the desired method.")
         elif isinstance(item, str):
@@ -527,56 +538,56 @@ class OptimizationVariableContainer:
             raise ValueError("item should be a node index or the name of the variable")
 
     @property
-    def unscaled(self):
+    def unscaled(self) -> OptimizationVariableList:
         """
         This method allows to intercept the scaled item and return the current node_index
         """
         return self._unscaled[self.node_index]
 
     @property
-    def scaled(self):
+    def scaled(self) -> OptimizationVariableList:
         """
         This method allows to intercept the scaled item and return the current node_index
         """
         return self._scaled[self.node_index]
 
-    def keys(self):
+    def keys(self) -> StrList:
         return self._unscaled[0].keys()
 
-    def key_index(self, key):
+    def key_index(self, key: Str) -> Range | AnyList:
         return self._unscaled[0][key].index
 
     @property
-    def shape(self):
+    def shape(self) -> Int:
         if isinstance(self._unscaled, list) and len(self._unscaled) == 0:
             raise RuntimeError("The optimization variable container is empty. Please initialize it first.")
         else:
             return self._unscaled[0].shape
 
     @property
-    def cx(self):
+    def cx(self) -> CX:
         return self.unscaled.cx
 
     @property
-    def cx_start(self):
+    def cx_start(self) -> CX:
         return self.unscaled.cx_start
 
     @property
-    def cx_intermediates_list(self):
+    def cx_intermediates_list(self) -> AnyList:
         return self.unscaled.cx_intermediates_list
 
     @property
-    def cx_end(self):
+    def cx_end(self) -> CX:
         return self.unscaled.cx_end
 
     def append(
         self,
-        name: str,
-        cx: list,
-        cx_scaled: list,
+        name: Str,
+        cx: AnyList,
+        cx_scaled: AnyList,
         mapping: BiMapping,
-        node_index: int,
-    ):
+        node_index: Int,
+    ) -> None:
         """
         Add a new variable to the list
 
@@ -596,7 +607,7 @@ class OptimizationVariableContainer:
         self._scaled[node_index].append(name, cx_scaled, mapping)
         self._unscaled[node_index].append_from_scaled(name, cx, self._scaled[node_index])
 
-    def __contains__(self, item: str):
+    def __contains__(self, item: Str) -> Bool:
         """
         If the item of name item is in the list
         """
@@ -605,14 +616,14 @@ class OptimizationVariableContainer:
 
         return item in self.unscaled
 
-    def __len__(self):
+    def __len__(self) -> Int:
         """
         The number of variables in the list
         """
 
         return len(self.unscaled)
 
-    def __iter__(self):
+    def __iter__(self) -> "OptimizationVariableContainer":
         """
         Allow for the list to be used in a for loop
 
@@ -624,7 +635,7 @@ class OptimizationVariableContainer:
         self._iter_idx = 0
         return self
 
-    def __next__(self):
+    def __next__(self) -> Str:
         """
         Get the next phase of the option list
 


### PR DESCRIPTION
## Summary
- refine typing for optimization variables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_68465ae1c4248330910df5c0cc118101